### PR TITLE
Added tests to validate groups data constraints

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,8 +1,18 @@
+class MembersCreatorInvitedValdiator < ActiveModel::Validator
+  def validate(record)
+    all_users = record.members + record.invited << record.creator
+    unless all_users.length == all_users.uniq.length
+      record.errors[:members] << 'Single user can only belong to creator or members or invited'
+      record.errors[:invited] << 'Single user can only belong to creator or members or invited'
+      record.errors[:creator] << 'Single user can only belong to creator or members or invited'
+    end
+  end
+end
+
 class Group < ActiveRecord::Base
   attr_accessible :description, :name
-  has_many :destinations, :dependent => :destroy
 
-  validates :description, :name, :presence => true
+  has_many :destinations, :dependent => :destroy
 
   belongs_to :creator, :class_name => 'User', :foreign_key => 'user_id'
 
@@ -11,4 +21,9 @@ class Group < ActiveRecord::Base
 
   has_many :pending_members, :dependent => :destroy
   has_many :invited, :through => :pending_members, :source => :user
+
+  validates :description, :name, :creator, :presence => true
+  validates :name, :length => { :minimum => 5, :maximum => 256 }
+  validates :description, :length => { :minimum => 5, :maximum => 1024 }
+  validates_with MembersCreatorInvitedValdiator
 end

--- a/spec/fixtures/core_users.yml
+++ b/spec/fixtures/core_users.yml
@@ -7,3 +7,13 @@ two:
   id: 2
   name: Homer Simpson
   subtype: false
+
+three:
+  id: 3
+  name: Max Hoffman
+  subtype: false
+
+four:
+  id: 4
+  name: Robert Lis
+  subtype: false

--- a/spec/fixtures/groups.yml
+++ b/spec/fixtures/groups.yml
@@ -1,7 +1,9 @@
 one:
   name: group
-  description: desc
+  description: descr
+  user_id: 2
 
 two:
   name: group2
-  description: desc2
+  description: descr2
+  user_id: 2

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -9,3 +9,16 @@ two:
   availability: true
   registered: true
   registered_at: <%= Time.now %>
+
+three:
+  core_user_id: 3
+  availability: true
+  registered: true
+  registered_at: <%= Time.now %>
+
+four:
+  core_user_id: 4
+  availability: true
+  registered: true
+  registered_at: <%= Time.now %>
+

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,8 +45,7 @@ describe User do
       user.groups_member_of.delete group
       user.save!
       user.groups_member_of.should_not include(group)
-      group.reload
-      group.members.should_not include(user)
+      group.members(true).should_not include(user)
     end
 
   end
@@ -95,11 +94,9 @@ describe User do
     group1.save!
     group2.save!
     user.destroy
-    group1.reload
-    group2.reload
     GroupMember.all.size.should == 0
-    group1.members.size.should == 0
-    group2.members.size.should == 0
+    group1.members(true).size.should == 0
+    group2.members(true).size.should == 0
   end
 
   context 'USER -> GROUP INVITATIONS' do
@@ -125,8 +122,7 @@ describe User do
     user.groups_invited_to.delete group
     user.save!
     user.groups_invited_to.should_not include(group)
-    group.reload
-    group.invited.should_not include(user)
+    group.invited(true).should_not include(user)
   end
 
   it 'should remove all invitations once the user is destroyed' do
@@ -139,11 +135,9 @@ describe User do
     group1.save!
     group2.save!
     user.destroy
-    group1.reload
-    group2.reload
     PendingMember.all.size.should == 0
-    group1.invited.size.should == 0
-    group2.invited.size.should == 0
+    group1.invited(true).size.should == 0
+    group2.invited(true).size.should == 0
   end
 
   context 'USER - GROUP POSSESSION' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -45,6 +45,7 @@ describe User do
       user.groups_member_of.delete group
       user.save!
       user.groups_member_of.should_not include(group)
+      group.reload
       group.members.should_not include(user)
     end
 
@@ -94,6 +95,8 @@ describe User do
     group1.save!
     group2.save!
     user.destroy
+    group1.reload
+    group2.reload
     GroupMember.all.size.should == 0
     group1.members.size.should == 0
     group2.members.size.should == 0
@@ -122,6 +125,7 @@ describe User do
     user.groups_invited_to.delete group
     user.save!
     user.groups_invited_to.should_not include(group)
+    group.reload
     group.invited.should_not include(user)
   end
 
@@ -135,6 +139,8 @@ describe User do
     group1.save!
     group2.save!
     user.destroy
+    group1.reload
+    group2.reload
     PendingMember.all.size.should == 0
     group1.invited.size.should == 0
     group2.invited.size.should == 0
@@ -209,5 +215,4 @@ describe User do
     user.destroy
     LocationPost.all.size.should == 0
   end
-
 end


### PR DESCRIPTION
I have added validations to groups. We should also think about validating size of destinations , members and invited to prevent any issues due to oversized sets ( some trying to fuck with us ). Look at places where I call .reload. for some reason in some cases until I call .reload the object has its relationships cached in memory which creates an issue, I am not sure if its an error or not, and if its gonna be an issue later on. 
