### PR TITLE
Identity Model provider enums

### DIFF
--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -1,6 +1,10 @@
 class Identity < ActiveRecord::Base
-  attr_accessible :provider_id, :token
+  attr_accessible :provider_id, :token, :provider
+
+  as_enum :provider, [ :eventhub, :facebook ]
 
   belongs_to :identifiable, :polymorphic => true
   belongs_to :user, :foreign_key => 'identifiable_id', :class_name => 'CoreUser'
+
+  validates :provider, :as_enum => true
 end

--- a/db/migrate/20130703093336_add_enum_property_to_identities.rb
+++ b/db/migrate/20130703093336_add_enum_property_to_identities.rb
@@ -1,0 +1,5 @@
+class AddEnumPropertyToIdentities < ActiveRecord::Migration
+  def change
+    add_column :identities, :provider_cd, :integer
+  end
+end

--- a/lib/assertion_handler.rb
+++ b/lib/assertion_handler.rb
@@ -70,7 +70,7 @@ class AssertionHandler
   end
 
   def register_user
-    identity_obj = Identity.new :provider_id => provider_response['id'], :token => @assertion
+    identity_obj = Identity.new :provider_id => provider_response['id'], :token => @assertion, :provider => @type
     identity_obj.save!
     @user = User.new :name => provider_response['name'], :availability => true, :registered => true, :registered_at => Time.now
     @user.identities << identity_obj

--- a/spec/fixtures/identities.yml
+++ b/spec/fixtures/identities.yml
@@ -3,15 +3,18 @@ one:
   token: 1234567890
   identifiable_id: 1
   identifiable_type: CoreUser
+  provider_cd: 0
 
 two:
   provider_id: 2
   token: 1234567890
   identifiable_id: 5
   identifiable_type: CoreUser
+  provider_cd: 0
 
 three:
   provider_id: 3
   token: 1234567890
   identifiable_id: 2
   identifiable_type: CoreUser
+  provider_cd: 0

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 describe Identity do
   fixtures :identities, :core_users, :users, :business_users
 
-
+  it 'should only assign provider facebook and eventhub' do
+    identity = Identity.new
+    identity.provider = :eventhub
+    identity.save!
+    identity.provider = :facebook
+    identity.save!
+    expect { identity.provider = :invalid_provider }.to raise_error(ArgumentError)
+  end
 
 end


### PR DESCRIPTION
This is a quick implementation for identities to have different providers

**Rob: Can you merge this quickly? Need it for something else**
